### PR TITLE
feat: show colors + better stderr handling

### DIFF
--- a/lua/tooltip/init.lua
+++ b/lua/tooltip/init.lua
@@ -1,79 +1,85 @@
 local util = require 'tooltip.util'
 
 local M = {}
-local patterns = {}
-local output_buffer
-local win_id
-local styled = false
+
+M.win_config = {
+  relative = 'cursor',
+  row = 1,
+  col = 0,
+  width = 50,
+  height = 2,
+  anchor = 'NW',
+  style = 'minimal',
+}
 
 M.setup = function (config)
-  patterns = config['patterns']
-  styled = config['styled']
+  M.patterns = config['patterns'] or {}
+  M.styled = config['styled'] or false
+
+  M.win_config.title = M.styled and 'output' or ''
+  M.win_config.border = M.styled and 'rounded' or 'none'
+end
+
+M._open_win = function ()
+  M.output_buffer = vim.api.nvim_create_buf(true, true)
+  M.win_id = vim.api.nvim_open_win(M.output_buffer, true, M.win_config)
+  M.term_id = vim.api.nvim_open_term(M.output_buffer, {})
 end
 
 M._run = function (command)
-  output_buffer = tonumber(vim.api.nvim_create_buf(true, true))
-
   local command_table = util._table_of(command)
 
   local obj = vim.system(command_table, {
     text = true,
   }):wait()
 
-  local has_stdout = obj.stdout ~= ''
-  local has_strerr = obj.stderr ~= ''
+  local stdout_trimmed = util._trim_trailing_newline(obj.stdout)
+  local stderr_trimmed = util._trim_trailing_newline(obj.stderr)
 
-  if has_stdout then
-    util._write_to_buf(output_buffer, obj.stdout)
-  end
-
-  if has_strerr then
-    util._write_to_buf(output_buffer, obj.stderr, has_stdout)
-  end
+  vim.api.nvim_chan_send(M.term_id, stdout_trimmed)
+  vim.api.nvim_chan_send(M.term_id, stderr_trimmed)
 end
 
-M._open_win = function ()
-  local lines = vim.api.nvim_buf_get_lines(output_buffer, 0, -1, true)
+M._resize = function ()
+  local lines = vim.api.nvim_buf_get_lines(M.output_buffer, 0, -1, true)
   local width = math.max(util._longest_line(lines), 6)
-  local height = vim.api.nvim_buf_line_count(output_buffer)
+  local height = vim.api.nvim_buf_line_count(M.output_buffer)
 
-  local config = {
-    relative = 'cursor',
-    row = 1,
-    col = 0,
+  vim.api.nvim_win_set_config(M.win_id, {
     width = width,
     height = height,
-    anchor = 'NW',
-    style = 'minimal',
-    border = styled and 'rounded' or 'none',
-    title = styled and 'output' or '',
-  }
-
-  win_id = vim.api.nvim_open_win(output_buffer, true, config)
+  })
 end
-
 
 M.show = function ()
   local file = util._file_name(0)
-  local command = util._command_for_file(file, patterns)
+  local command = util._command_for_file(file, M.patterns)
+
+  M._open_win()
   M._run(command)
 
-  vim.api.nvim_buf_set_keymap(output_buffer, 'n', 'q', '', {
+  -- this is needed to let the output finish sending to terminal channel
+  vim.defer_fn(function()
+    if vim.api.nvim_win_is_valid(M.win_id) then
+      M._resize()
+    end
+  end, 1)
+
+  vim.api.nvim_buf_set_keymap(M.output_buffer, 'n', 'q', '', {
     callback = function ()
       require('tooltip').close()
     end
   })
 
-  M._open_win()
 end
 
 M.close = function ()
-  vim.api.nvim_win_close(win_id, true)
-  vim.api.nvim_buf_delete(output_buffer, {})
+  vim.api.nvim_win_close(M.win_id, true)
+  vim.api.nvim_buf_delete(M.output_buffer, { force = true })
 end
 
 M._clear = function ()
-  patterns = {}
+  M.patterns = {}
 end
 
 return M

--- a/lua/tooltip/init.lua
+++ b/lua/tooltip/init.lua
@@ -20,8 +20,16 @@ M._run = function (command)
     text = true,
   }):wait()
 
-  util._write_to_buf(output_buffer, obj.stdout)
-  util._write_to_buf(output_buffer, obj.stderr, true)
+  local has_stdout = obj.stdout ~= ''
+  local has_strerr = obj.stderr ~= ''
+
+  if has_stdout then
+    util._write_to_buf(output_buffer, obj.stdout)
+  end
+
+  if has_strerr then
+    util._write_to_buf(output_buffer, obj.stderr, has_stdout)
+  end
 end
 
 M._open_win = function ()

--- a/lua/tooltip/util.lua
+++ b/lua/tooltip/util.lua
@@ -20,14 +20,10 @@ util._table_of = function (data, separator)
   return t
 end
 
-util._write_to_buf = function (output_buffer, data, append)
-  local separator = '\n'
-  local lines = util._table_of(data, separator)
-
-  local start = append and -1 or 0
-
-  vim.api.nvim_buf_set_lines(output_buffer, start, -1, true, lines)
+util._trim_trailing_newline = function (str)
+  return str:gsub('\n$', '')
 end
+
 
 util._command_for_file = function (file, patterns)
   local file_type

--- a/lua/tooltip/util.lua
+++ b/lua/tooltip/util.lua
@@ -24,7 +24,6 @@ util._trim_trailing_newline = function (str)
   return str:gsub('\n$', '')
 end
 
-
 util._command_for_file = function (file, patterns)
   local file_type
   for extension in string.gmatch(file, '%.(%w+)') do


### PR DESCRIPTION
- **fix: does not create a new line at every 'n' anymore   handles stderr**
- **remove empty space of stdout or stderr if they don't have output**
- **will now show colors**
- **formating**

Details of feature:

- Got rid of global variables and attached it to the plugin table instead
- stdout & stderr is better handled since it is now sent through channels to the terminal view instead of just a simple buffer and writing to the buffer
- Because a terminal view is being used now it will accept colors (before there would be terminal color escape sequences)
