### PR TITLE
override default file pattern/command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,31 +24,31 @@ See `:help tooltip.nvim`
 
 ## Setup
 
-There are 2 parts that will need to be configured before using the plugin:
-1. Set up a pattern for the command that will execute each file extension
-2. call the `show()` function that will take the current file, see if there is a pattern set up for it and then execute it. After execution the stdout (or stderr) will be outputed in a new floating window where the cursor is at.
+Only set up that is needed is to set up a keymap to show the tooltip. There is an optional step to set up your own custom commands for a file pattern or if you want a command for a file that is not set up by default. 
+
+To set up file patterns it is passed as a table attribute to the `setup()`. See bellow for example:
 
 Ex. 
 ``` lua
 local tooltip = require('tooltip')
 
-tooltip.setup({
+tooltip.setup {
   patterns = {
     ['.js'] = 'node %s',
     ['.rb'] = 'ruby %s',
     ['.go'] = 'go run %s',
     -- ['file extenstion'] = 'command_to_execute %s' (%s) will be replaced by the file path
-    -- what is set up here will override the default mappings
+    -- what is set up here will override the default mappings if there is already a command set up for that file pattern
   },
-})
+}
 
 -- universal-tooltip keymap (run program)
-vim.keymap.set('n', '<leader>rp', function ()
+vim.keymap.set('n', '<leader><leader>r', function ()
     tooltip.show()
 end)
 ```
 
-### Default Mappings
+### Default File-Command Mappings
 
 This plugin comes with default mappings so there is as little set up as possible. If you do find your self needing to override the command that gets executed with each file pattern then you can set your custom command, shown above. 
 

--- a/doc/tags
+++ b/doc/tags
@@ -1,3 +1,4 @@
+default_file_patterns	tooltip.txt	/*default_file_patterns*
 tooltip.close()	tooltip.txt	/*tooltip.close()*
 tooltip.nvim	tooltip.txt	/*tooltip.nvim*
 tooltip.setup()	tooltip.txt	/*tooltip.setup()*

--- a/doc/tooltip.txt
+++ b/doc/tooltip.txt
@@ -15,14 +15,17 @@ tooltip.setup({config})
               - patterns: (Map) with the file extension as the key and the
                 command to be ran as the value.
                   Note: the value representing the command will be formated 
-                  following regular c printf rules, replacing the %s with the file to be
-                  run. 
+                  following regular c printf rules, replacing the %s with the filepath to be
+                  ran. 
+                  - any file pattern set up here will override default's (look
+                    at |default_file_patterns|)
               - styled: (Boolean) that will set the window border `rounded` and title
                 `output` >
 
     Example.
     
     tooltip.setup({
+      styled = true,
       patterns = {
         [".js"] = "node %s",
         [".rb"] = "ruby %s",
@@ -34,7 +37,7 @@ tooltip.setup({config})
 tooltip.show()
   
   Will get the current file in the buffer of the current window get the
-  command to execute it (if set up with `tooltip.setup()`), run the command
+  command to execute it (if set up with |tooltip.setup()|), run the command
   and output to stdout/stderr to a buffer and then show that buffer at the pos
   the cursor is at.
 
@@ -51,5 +54,21 @@ tooltip.close()
 
   Note: `q` is automatically added as a keymap to the buffer to call
   this function.
+
+                                                       *default_file_patterns*
+default_file_patterns
+
+This plugin comes with default mappings so there is as little set up as possible. If you do find your self needing to override the command that gets executed with each file pattern then you can set your custom command, shown in |tooltip.setup()|
+
+| File pattern | Command          |
+| ------------ | ---------------- |
+| '.js'        | 'node %s'        |
+| '.rb'        | 'ruby %s'        |
+| '.go'        | 'go run %s'      |
+| '.erl'       | 'escript %s'     |
+| '.scala'     | 'scala %s'       |
+| '.clj'       | 'clojure -M %s'  |
+| '.lua'       | 'lua %s'         |
+
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/lua/tooltip/init.lua
+++ b/lua/tooltip/init.lua
@@ -13,11 +13,14 @@ M.win_config = {
 }
 
 M.setup = function (config)
-  M.patterns = util._defaul_file_patterns
   M.styled = config['styled'] or false
 
   M.win_config.title = M.styled and 'output' or ''
   M.win_config.border = M.styled and 'rounded' or 'none'
+
+  if (config['patterns'] ~= nil) then
+    util._override_file_patterns(config['patterns'])
+  end
 end
 
 M._open_win = function ()
@@ -41,7 +44,7 @@ end
 M._resize = function ()
   local lines = vim.api.nvim_buf_get_lines(M.output_buffer, 0, -1, true)
   local width = math.max(util._longest_line(lines), 6)
-  local height = vim.api.nvim_buf_line_count(M.output_buffer)
+  local height = vim.api.nvim_buf_line_count(M.output_buffer) - 1 -- the output always has an extra \n so the -1 takes care of this instead
 
   vim.api.nvim_win_set_config(M.win_id, {
     width = width,
@@ -53,7 +56,7 @@ M.show = function ()
   vim.cmd('w')
 
   local file = util._file_name(0)
-  local command = util._command_for_file(file, M.patterns)
+  local command = util._command_for_file(file, util.default_file_patterns)
 
   M._open_win()
   M._run(command)

--- a/lua/tooltip/util.lua
+++ b/lua/tooltip/util.lua
@@ -42,8 +42,6 @@ util._trim_trailing_newline = function (str)
 end
 
 util._command_for_file = function (file, patterns)
-  P(patterns)
-
   local file_type
   for extension in string.gmatch(file, '%.(%w+)') do
     file_type = string.format('.%s', extension)

--- a/lua/tooltip/util.lua
+++ b/lua/tooltip/util.lua
@@ -1,6 +1,6 @@
 local util = {}
 
-util._default_file_patterns = {
+util.default_file_patterns = {
   ['.js'] = 'node %s',
   ['.rb'] = 'ruby %s',
   ['.go'] = 'go run %s',
@@ -8,7 +8,14 @@ util._default_file_patterns = {
   ['.scala'] = 'scala %s',
   ['.clj'] = 'clojure -M %s',
   ['.lua'] = 'lua %s',
+  ['.hs'] = 'runghc %s',
 }
+
+util._override_file_patterns = function (patterns)
+  for pattern, command in pairs(patterns) do
+    util.default_file_patterns[pattern] = command
+  end
+end
 
 util._file_name = function (output_buffer)
   return vim.api.nvim_buf_get_name(output_buffer)
@@ -35,6 +42,8 @@ util._trim_trailing_newline = function (str)
 end
 
 util._command_for_file = function (file, patterns)
+  P(patterns)
+
   local file_type
   for extension in string.gmatch(file, '%.(%w+)') do
     file_type = string.format('.%s', extension)


### PR DESCRIPTION
- **fix: does not create a new line at every 'n' anymore + handles stderr**
- **remove empty space of stdout or stderr if they dont have output**
- **will now show colors**
- **formating**
- **Automatically save file when .show() is ran**
- **Set default file pattern mappings**
- **Rename default_mappings -> default_file_patterns**
- **Update README.md**
- **Fix: erlang command**
- **add ability to override default mappings + update documentation**
- **for got i left a personal function P(), removed it so it passes CI**
