### PR TITLE
Update CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-22.04, macos-14]
         rev: [nightly, v0.9.5, v0.10.0]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
mac-12 is deprecated:
https://github.com/actions/runner-images/issues/10721